### PR TITLE
Ignore changes on instance_count of task instance group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -502,6 +502,14 @@ resource "aws_emr_instance_group" "task" {
   bid_price          = var.task_instance_group_bid_price
   ebs_optimized      = var.task_instance_group_ebs_optimized
   autoscaling_policy = var.task_instance_group_autoscaling_policy
+
+  # with autoscaling set, instance_count value varies during EMR lifecycle, we get rid
+  # of state changes in order to avoid unwanted resizing
+  lifecycle {
+    ignore_changes = [
+      instance_count,
+    ]
+  }
 }
 
 module "dns_master" {


### PR DESCRIPTION
## what
* Set `ignore_changes` on `instance_count` attribute of resource `aws_emr_instance_group.task`

## why
* When autoscaling is set on resource `aws_emr_instance_group.task` attribute `instance_count` is valid only upon resource creation, then during the lifecycle of the cluster the count is decided by autoscaling. Subsequent `terraform apply` would reset the instance_count to the desired state, leading to unwanted instance_group resizes.
